### PR TITLE
feat: add 429 logic from AMD docs

### DIFF
--- a/src/common/fetch.rs
+++ b/src/common/fetch.rs
@@ -47,6 +47,18 @@ pub async fn fetch_url(
                         url,
                         response.status()
                     );
+                    let headers = response.headers();
+                    if let Some(retry_interval_value) = headers.get("retry-after") {
+                        // Try retrieve the value from the headers
+                        if let Ok(retry_interval_str) = retry_interval_value.to_str() {
+                            // Parse value as string
+                           if let Ok(retry_interval) = retry_interval_str.parse::<u64>() {
+                               // Override the existing retry_sleep with the value given by AMD
+                               // Note: original logic will still be applied on next pass if AMD doesn't provide a value.
+                               retry_sleep_ms = retry_interval;
+                           }
+                        }
+                    }
                 }
             }
             Err(err) => {


### PR DESCRIPTION
INF-48: adds logic for when a request doesn't get a 2XX status code to take the retry-after value and override the wait_ms with that time