### PR TITLE
feat: ensure requests can only be run one at a time


### DIFF
--- a/src/common/fetch.rs
+++ b/src/common/fetch.rs
@@ -65,11 +65,11 @@ pub async fn fetch_url(
                         // Try retrieve the value from the headers
                         if let Ok(retry_interval_str) = retry_interval_value.to_str() {
                             // Parse value as string
-                           if let Ok(retry_interval_seconds) = retry_interval_str.parse::<u64>() {
-                               // Override the existing retry_sleep with the value given by AMD
-                               // Note: original logic will still be applied on next pass if AMD doesn't provide a value.
-                               retry_sleep_ms = retry_interval_seconds * 1000;
-                           }
+                            if let Ok(retry_interval_seconds) = retry_interval_str.parse::<u64>() {
+                                // Override the existing retry_sleep with the value given by AMD
+                                // Note: original logic will still be applied on next pass if AMD doesn't provide a value.
+                                retry_sleep_ms = retry_interval_seconds * 1000;
+                            }
                         }
                     }
                 }

--- a/src/common/fetch.rs
+++ b/src/common/fetch.rs
@@ -22,7 +22,7 @@ pub async fn fetch_url(
 ) -> error::Result<Option<Bytes>> {
     trace!("fetch_url: url: {}", url);
 
-    let _gaurd = tokio::time::timeout(Duration::from_secs(10), FETCH_LOCK.lock())
+    let _guard = tokio::time::timeout(Duration::from_secs(10), FETCH_LOCK.lock())
         .await
         .map_err(|e| error::fetch(e, Some("failed to acquire fetch lock".to_string())))?;
 

--- a/src/common/fetch.rs
+++ b/src/common/fetch.rs
@@ -24,7 +24,12 @@ pub async fn fetch_url(
 
     let _guard = tokio::time::timeout(Duration::from_secs(10), FETCH_LOCK.lock())
         .await
-        .map_err(|e| error::fetch(e, Some("failed to acquire fetch lock".to_string())))?;
+        .map_err(|e| {
+            error::lock_timeout(
+                e,
+                Some("failed to acquire fetch lock in 10 seconds".to_string()),
+            )
+        })?;
 
     let client = create_http_client()?;
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -19,8 +19,8 @@ struct Inner {
 
 impl Error {
     pub(crate) fn new<E>(kind: Kind, msg: Option<String>, source: Option<E>) -> Error
-        where
-            E: Into<BoxError>,
+    where
+        E: Into<BoxError>,
     {
         Error {
             inner: Box::new(Inner {
@@ -31,13 +31,12 @@ impl Error {
         }
     }
 
-    pub(crate) fn new_msg(kind: Kind, msg: Option<String>) -> Error
-    {
+    pub(crate) fn new_msg(kind: Kind, msg: Option<String>) -> Error {
         Error {
             inner: Box::new(Inner {
                 kind,
                 msg,
-                source: None
+                source: None,
             }),
         }
     }
@@ -75,6 +74,7 @@ impl fmt::Display for Error {
             Kind::Io => f.write_str("io error")?,
             Kind::Cert => f.write_str("cert error")?,
             Kind::OpenSSL => f.write_str("OpenSSL error")?,
+            Kind::LockTimeout => f.write_str("Lock Timeout error")?,
         };
 
         if let Some(msg) = &self.inner.msg {
@@ -102,7 +102,8 @@ pub(crate) enum Kind {
     Fetch,
     Io,
     Cert,
-    OpenSSL
+    OpenSSL,
+    LockTimeout,
 }
 
 // constructors
@@ -137,4 +138,8 @@ pub(crate) fn map_conversion_err<E: Into<BoxError>>(e: E) -> Error {
 
 pub(crate) fn openssl<E: Into<BoxError>>(e: E, msg: Option<String>) -> Error {
     Error::new(Kind::OpenSSL, msg, Some(e))
+}
+
+pub(crate) fn lock_timeout<E: Into<BoxError>>(e: E, msg: Option<String>) -> Error {
+    Error::new(Kind::LockTimeout, msg, Some(e))
 }


### PR DESCRIPTION
See https://linear.app/litprotocol/issue/INF-146/investigate-how-requests-are-currently-sent#comment-4976d73a for rationale.